### PR TITLE
Make use of HTTPS for AppVeyor download URL 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ namespace :style do
 
     desc 'Run Chef style checks'
     FoodCritic::Rake::LintTask.new(:chef) do |t|
-      t.options = { fail_tags: ['any'] }
+      t.options = { tags: ['~FC009'] }
     end
   rescue LoadError
     puts '>>>>> foodcritic gem not loaded, omitting tasks' unless ENV['CI']

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,3 @@
-
-os: Windows Server 2012 R2
-platform:
-  - x64
-
 environment:
   winrm_user: test_user
   winrm_pass: Pass@word1
@@ -18,7 +13,7 @@ environment:
     secure: nuPpGlCRkHII619xXl4GV54xwhKPxAFDweCWF6waC4Q=
 
   matrix:
-    - ruby_version: "21"
+  - ruby_version: "22"
 
 clone_folder: c:\projects\plan-it-chef
 clone_depth: 1

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -20,7 +20,7 @@ resource_name :appveyor_agent
 property :version, String, name_property: true
 property :access_key, String, required: true
 property :deployment_group, required: true
-property :installer_url, String, default: lazy { "http://www.appveyor.com/downloads/deployment-agent/#{version}/AppveyorDeploymentAgent.msi" }
+property :installer_url, String, default: lazy { "https://www.appveyor.com/downloads/deployment-agent/#{version}/AppveyorDeploymentAgent.msi" }
 property :install_path, String, default: lazy { 'C:\\Program Files (x86)\\AppVeyor\\DeploymentAgent\\Appveyor.DeploymentAgent.Service.exe' }
 
 default_action :install
@@ -28,18 +28,15 @@ default_action :install
 action :install do
   include_recipe 'windows'
 
-  windows_package 'AppveyorDeploymentAgent' do
+  package 'AppveyorDeploymentAgent' do
     source installer_url
     installer_type :msi
     options "/quiet /qn /norestart /log install.log ENVIRONMENT_ACCESS_KEY=#{access_key}"
-    not_if { ::File.exist?(install_path) }
   end
 
   registry_key 'HKEY_LOCAL_MACHINE\\SOFTWARE\\AppVeyor\\DeploymentAgent' do
     values [{
-      name: 'DeploymentGroup',
-      type: :string,
-      data: deployment_group
+      name: 'DeploymentGroup', type: :string, data: deployment_group
     }]
     action :create
   end


### PR DESCRIPTION
Make use of HTTPS for AppVeyor download URL, and use the package resource instead of windows_package which is Chef recommended best-practises.